### PR TITLE
Warning

### DIFF
--- a/hashes-to-numpy-2.py
+++ b/hashes-to-numpy-2.py
@@ -31,7 +31,7 @@ def main():
         for n, filename in enumerate(args.intersect):
             print('...loading intersect {}'.format(n + 1), end='\r')
             sig = sourmash_lib.signature.load_one_signature(filename,
-                                                            select_ksize=args.ksize)
+                                                            ksize=args.ksize)
             mh = sig.minhash.downsample_scaled(args.scaled)
             hashes = mh.get_mins()
             intersect_hashes.update(hashes)
@@ -41,7 +41,7 @@ def main():
     sig_hashes = {}
     for n, filename in enumerate(args.inp_signatures):
         print('... {}'.format(n + 1), end='\r')
-        sig = sourmash_lib.load_one_signature(filename,select_ksize=args.ksize)
+        sig = sourmash_lib.load_one_signature(filename, size=args.ksize)
         mh = sig.minhash.downsample_scaled(args.scaled)
         hashes = mh.get_mins()
 
@@ -50,7 +50,6 @@ def main():
             hashes.intersection_update(intersect_hashes)
 
         sig_hashes[filename] = hashes
-
         for k in hashes:
             counts[k] += 1
 

--- a/hashes-to-numpy-2.py
+++ b/hashes-to-numpy-2.py
@@ -41,7 +41,7 @@ def main():
     sig_hashes = {}
     for n, filename in enumerate(args.inp_signatures):
         print('... {}'.format(n + 1), end='\r')
-        sig = sourmash_lib.load_one_signature(filename, size=args.ksize)
+        sig = sourmash_lib.load_one_signature(filename, ksize=args.ksize)
         mh = sig.minhash.downsample_scaled(args.scaled)
         hashes = mh.get_mins()
 

--- a/hashes-to-numpy-2.py
+++ b/hashes-to-numpy-2.py
@@ -9,7 +9,8 @@ import argparse
 import collections
 import sourmash_lib.signature
 import numpy
-
+import os
+import warnings
 
 def main():
     p = argparse.ArgumentParser()
@@ -41,18 +42,20 @@ def main():
     sig_hashes = {}
     for n, filename in enumerate(args.inp_signatures):
         print('... {}'.format(n + 1), end='\r')
-        sig = sourmash_lib.load_one_signature(filename, ksize=args.ksize)
-        mh = sig.minhash.downsample_scaled(args.scaled)
-        hashes = mh.get_mins()
+        if os.path.isfile(filename):
+            sig = sourmash_lib.load_one_signature(filename, ksize=args.ksize)
+            mh = sig.minhash.downsample_scaled(args.scaled)
+            hashes = mh.get_mins()
 
-        if intersect_hashes:
-            hashes = set(hashes)
-            hashes.intersection_update(intersect_hashes)
+            if intersect_hashes:
+                hashes = set(hashes)
+                hashes.intersection_update(intersect_hashes)
 
-        sig_hashes[filename] = hashes
-        for k in hashes:
-            counts[k] += 1
-
+            sig_hashes[filename] = hashes
+            for k in hashes:
+                counts[k] += 1
+        else:
+            print(filename + ' not found. Skipping.')
     print('\n...done. Now finding common hashes among >= {} samples'.format(args.threshold))
 
     n = 0
@@ -80,7 +83,7 @@ def main():
     hashdict = {}
     for n, k in enumerate(hashlist):
         hashdict[k] = n                   # hash -> index in hashlist
-                         
+
     print('calculating matrix {} x {}'.format(len(abundant_hashes),
                                               len(abundant_hashes)))
 
@@ -108,7 +111,7 @@ def main():
 
     with open(args.output_name + '.labels.txt', 'w') as fp:
         fp.write("\n".join(map(str, hashlist)))
-            
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
For some reason (failed sequencing?) the tara lists of files by region contain ERR values that are not actually in the dataset. To save a lot of permutations on my end I added a warning message to skip over files if they aren't found in the path. If they are, it continues as normal. 